### PR TITLE
chore: Rename allow field to allowed_accounts

### DIFF
--- a/src/account.rs
+++ b/src/account.rs
@@ -72,7 +72,7 @@ pub struct ExternalAuthorization {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub auth_users: Option<BTreeSet<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub allow: Option<BTreeSet<String>>,
+    pub allowed_accounts: Option<BTreeSet<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub xkey: Option<String>,
 }


### PR DESCRIPTION
## Feature or Problem

This renames the `ExternalAuthorization` struct's `allow` field to `allowed_accounts` to [match upstream published field](https://github.com/nats-io/jwt/blob/v2.7.3/v2/account_claims.go#L189).

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
