### PR TITLE
chore: Align with NATS JWT Go-implementation

### DIFF
--- a/src/account.rs
+++ b/src/account.rs
@@ -108,6 +108,7 @@ pub struct Account {
     pub authorization: Option<ExternalAuthorization>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub trace: Option<MsgTrace>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub info: Option<Info>,
     #[serde(flatten)]
     pub generic_fields: GenericFields,

--- a/src/account.rs
+++ b/src/account.rs
@@ -79,7 +79,7 @@ pub struct ExternalAuthorization {
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct MsgTrace {
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "dest", skip_serializing_if = "Option::is_none")]
     pub destination: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sampling: Option<u64>,
@@ -106,7 +106,7 @@ pub struct Account {
     pub mappings: Mapping,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub authorization: Option<ExternalAuthorization>,
-    #[serde(flatten, skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub trace: Option<MsgTrace>,
     pub info: Option<Info>,
     #[serde(flatten)]

--- a/src/account.rs
+++ b/src/account.rs
@@ -15,8 +15,8 @@ pub struct OperatorLimits {
     pub account: Option<AccountLimits>,
     #[serde(flatten, skip_serializing_if = "Option::is_none")]
     pub jetstream: Option<JetStreamLimits>,
-    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
-    pub tiered_limits: BTreeMap<String, Limits>,
+    #[serde(flatten, skip_serializing_if = "Option::is_none")]
+    pub tiered_limits: Option<BTreeMap<String, Limits>>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
@@ -88,22 +88,22 @@ pub struct MsgTrace {
 #[derive(Debug, Serialize, Deserialize, Clone, Builder)]
 #[builder(setter(into), default)]
 pub struct Account {
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub imports: Vec<Import>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub exports: Vec<Export>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub imports: Option<Vec<Import>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub exports: Option<Vec<Export>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub limits: Option<OperatorLimits>,
     //#[serde(skip_serializing_if = "BTreeMap::is_empty")]
     //pub signing_keys: BTreeMap<String, UserScope>,
-    #[serde(skip_serializing_if = "IndexSet::is_empty")]
-    pub signing_keys: IndexSet<SigningKey>,
-    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
-    pub revocations: BTreeMap<String, u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub signing_keys: Option<IndexSet<SigningKey>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub revocations: Option<BTreeMap<String, u64>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default_permissions: Option<Permissions>,
-    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
-    pub mappings: Mapping,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mappings: Option<Mapping>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub authorization: Option<ExternalAuthorization>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -123,12 +123,12 @@ impl Default for Account {
             },
             info: None,
             default_permissions: None,
-            imports: Vec::new(),
-            exports: Vec::new(),
-            signing_keys: IndexSet::new(),
-            revocations: BTreeMap::new(),
+            imports: None,
+            exports: None,
+            signing_keys: None,
+            revocations: None,
             limits: None,
-            mappings: BTreeMap::new(),
+            mappings: None,
             authorization: None,
             trace: None,
         }

--- a/src/account.rs
+++ b/src/account.rs
@@ -104,7 +104,7 @@ pub struct Account {
     pub default_permissions: Option<Permissions>,
     #[serde(flatten, skip_serializing_if = "BTreeMap::is_empty")]
     pub mappings: Mapping,
-    #[serde(flatten, skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub authorization: Option<ExternalAuthorization>,
     #[serde(flatten, skip_serializing_if = "Option::is_none")]
     pub trace: Option<MsgTrace>,

--- a/src/account.rs
+++ b/src/account.rs
@@ -102,7 +102,7 @@ pub struct Account {
     pub revocations: BTreeMap<String, u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default_permissions: Option<Permissions>,
-    #[serde(flatten, skip_serializing_if = "BTreeMap::is_empty")]
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
     pub mappings: Mapping,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub authorization: Option<ExternalAuthorization>,

--- a/src/operator.rs
+++ b/src/operator.rs
@@ -5,12 +5,13 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Serialize, Deserialize, Clone, Builder)]
 #[builder(setter(into), default)]
 pub struct Operator {
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub signing_keys: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub signing_keys: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub account_server_url: Option<String>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub operator_service_urls: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub operator_service_urls: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub system_account: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub assert_server_version: Option<String>,
@@ -28,10 +29,10 @@ impl Default for Operator {
                 claim_type: ClaimType::Operator,
                 ..Default::default()
             },
-            signing_keys: Vec::new(),
+            signing_keys: None,
             account_server_url: None,
             strict_signing_key_usage: None,
-            operator_service_urls: Vec::new(),
+            operator_service_urls: None,
             system_account: None,
             assert_server_version: None,
         }

--- a/src/types.rs
+++ b/src/types.rs
@@ -5,6 +5,8 @@ use std::time::Duration;
 
 use crate::{user::UserPermissionLimits, ClaimType};
 
+pub const NO_LIMIT: i64 = -1;
+
 #[derive(Debug, Serialize, Deserialize, Clone, Hash, PartialEq, Eq)]
 pub struct NatsLimits {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -13,6 +15,16 @@ pub struct NatsLimits {
     pub data: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub payload: Option<i64>,
+}
+
+impl Default for NatsLimits {
+    fn default() -> Self {
+        Self {
+            subs: Some(NO_LIMIT),
+            data: Some(NO_LIMIT),
+            payload: Some(NO_LIMIT),
+        }
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Hash, PartialEq, Eq)]

--- a/src/user.rs
+++ b/src/user.rs
@@ -1,4 +1,4 @@
-use crate::types::{GenericFields, Limits, Permissions};
+use crate::types::{GenericFields, Limits, NatsLimits, Permissions};
 use crate::{Claim, ClaimType, Claims};
 use serde::{Deserialize, Serialize};
 
@@ -39,7 +39,7 @@ impl User {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, Default, Clone, Hash, Eq, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Clone, Hash, Eq, PartialEq)]
 pub struct UserPermissionLimits {
     #[serde(flatten)]
     pub permissions: Permissions,
@@ -49,4 +49,18 @@ pub struct UserPermissionLimits {
     pub bearer_token: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub allowed_connection_types: Option<Vec<String>>,
+}
+
+impl Default for UserPermissionLimits {
+    fn default() -> Self {
+        Self {
+            permissions: Permissions::default(),
+            limits: Some(Limits {
+                nats_limits: Some(NatsLimits::default()),
+                user_limits: None,
+            }),
+            bearer_token: None,
+            allowed_connection_types: None,
+        }
+    }
 }


### PR DESCRIPTION
## Feature or Problem

I noticed there were a few differences in terms of how things were serialized and deserialized, so I thought I'd adjust things to match the Go implementation more closely.

Beyond putting most fields inside of an Option and then skipping serialization if it's empty, I also:
* Changed the `std::time::Duration` serialization to match Go's `time.Duration` serialization, which meant (de)serializing things into nano seconds rather than separate "secs" and "nanos" fields like Rust does.
* Removed flattening from fields that are not embedded in Go (`authorization`, `mappings`, `trace` under Account)  so that they show up as nested entries as expected.
* Changed `Account` and `User` default values such that they allow connections and subscriptions to be made without explicitly setting limits (thus matching upstream Go implementation).

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
